### PR TITLE
m30s-common: remove eSCO Transport Unit Size to 16

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -30,8 +30,6 @@
 /* 'strings libbluetooth.so' */
 #define BTA_AV_SINK_INCLUDED TRUE
 
-#define BTM_ESCO_TRANSPORT_UNIT_SIZE_PCM16
-
 #pragma pop_macro("PROPERTY_VALUE_MAX")
 
 #endif /* _BDROID_BUILDCFG_H */


### PR DESCRIPTION
* This is now handled in kernel https://github.com/GalaxyM30s/android_kernel_samsung_m30s/commit/72002a9ef94ac7720529567c134bfbe07d69dbca

Signed-off-by: santhosh6194 <santhosh6194@gmail.com>